### PR TITLE
Move dev scripts to utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ src/
 │   ├── login.test.js
 └── app.js
 ```
+
+El proyecto incluye además un directorio `utils/` con scripts de
+verificación de servicios externos (MongoDB, Brevo y Cloudinary).
 ---
 
 ## Mantenimiento del formato y control de calidad

--- a/scripts/testBrevo.js
+++ b/scripts/testBrevo.js
@@ -1,4 +1,0 @@
-import Brevo from '@getbrevo/brevo'
-
-console.log('🦽Brevo:', Brevo) // Muestra qué se está importando exactamente
-console.log('🦽API Instance:', new Brevo.TransactionalEmailsApi()) // Verifica la estructura interna

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,14 @@
+# Utilidades de desarrollo
+
+Este directorio agrupa scripts independientes utilizados para verificar la
+configuración de servicios externos durante el desarrollo.
+
+- **setup.js**: Comprueba la conexión con MongoDB ejecutando una conexión simple
+  y cerrándola inmediatamente.
+- **testBrevo.js**: Muestra la estructura del SDK de Brevo para confirmar que la
+  instalación es correcta.
+- **testCloudinary.js**: Sube una imagen de prueba a Cloudinary y reporta el
+  resultado en consola.
+
+Estos archivos no forman parte de la lógica de la aplicación, pero pueden ser de
+ayuda para diagnosticar problemas de dependencias o credenciales.

--- a/utils/setup.js
+++ b/utils/setup.js
@@ -1,5 +1,12 @@
 import mongoose from 'mongoose'
 
+/**
+ * Script de utilidad para comprobar la conexión con MongoDB.
+ * Permite verificar de manera aislada que las credenciales y la
+ * red son correctas antes de ejecutar las pruebas o levantar el
+ * servidor de desarrollo.
+ */
+
 const uri =
   process.env.MONGO_TEST_URI ||
   'mongodb+srv://andresdavidgr2898:FBeXisVBdldRBlfw@finance.v4nq4j2.mongodb.net/?retryWrites=true&w=majority&appName=Finance'

--- a/utils/testBrevo.js
+++ b/utils/testBrevo.js
@@ -1,0 +1,10 @@
+import Brevo from '@getbrevo/brevo'
+
+/**
+ * Utilidad para verificar la instalación y estructura del SDK de Brevo.
+ * Imprime por consola el objeto importado y crea una instancia básica
+ * para comprobar que las dependencias están correctamente instaladas.
+ */
+
+console.log('🦽Brevo:', Brevo) // Muestra qué se está importando exactamente
+console.log('🦽API Instance:', new Brevo.TransactionalEmailsApi()) // Verifica la estructura interna

--- a/utils/testCloudinary.js
+++ b/utils/testCloudinary.js
@@ -1,5 +1,11 @@
 import cloudinary from '../task-management/config/cloudinary.js'
 
+/**
+ * Script de utilidad para comprobar la configuración de Cloudinary.
+ * Sube una imagen de prueba y muestra el resultado por consola para
+ * confirmar que las credenciales y la red funcionan correctamente.
+ */
+
 const testCloudinary = async () => {
   try {
     const result = await cloudinary.uploader.upload(


### PR DESCRIPTION
## Summary
- move dev helper scripts to `utils/`
- explain the utility scripts in `utils/README.md`
- document utils folder in main README
