### PR TITLE
Add wildcard origin support for CORS

### DIFF
--- a/task-management/middlewares/security/corsMiddleware.js
+++ b/task-management/middlewares/security/corsMiddleware.js
@@ -3,13 +3,34 @@ import cors from 'cors'
 // =========================================
 // Lista de orígenes permitidos
 // =========================================
+// Define en tu archivo `.env` la variable `ALLOWED_ORIGINS` separando
+// los dominios con comas. Puedes emplear comodines para subdominios con
+// el formato `*.dominio.com`. Ejemplo:
+// ALLOWED_ORIGINS=https://*.netlify.app,https://localhost:3000
 const allowedOrigins = process.env.ALLOWED_ORIGINS
   ? process.env.ALLOWED_ORIGINS.split(',').map((origin) => origin.trim())
   : []
 
+// ======================================================
+// Convierte un patrón (posiblemente con '*') en RegExp
+// ======================================================
+const patternToRegex = (pattern) => {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const regexStr = `^${escaped.replace(/\\\*/g, '.*')}$`
+  return new RegExp(regexStr)
+}
+
+// ======================================================
+// Verifica si el origen está permitido considerando comodines
+// ======================================================
+export const isAllowedOrigin = (origin, origins = allowedOrigins) => {
+  if (!origin) return true
+  return origins.some((allowed) => patternToRegex(allowed).test(origin))
+}
+
 const corsOptions = {
   origin: function (origin, callback) {
-    if (!origin || allowedOrigins.includes(origin)) {
+    if (isAllowedOrigin(origin)) {
       callback(null, true)
     } else {
       callback(new Error(`Origen no permitido por CORS: ${origin}`))

--- a/test/unit/isAllowedOrigin.test.js
+++ b/test/unit/isAllowedOrigin.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { isAllowedOrigin } from '../../task-management/middlewares/security/corsMiddleware.js'
+
+describe('isAllowedOrigin', () => {
+  it('permite origenes undefined', () => {
+    expect(isAllowedOrigin(undefined, ['https://example.com'])).toBe(true)
+  })
+
+  it('acepta coincidencias exactas', () => {
+    const origins = ['https://example.com']
+    expect(isAllowedOrigin('https://example.com', origins)).toBe(true)
+  })
+
+  it('reconoce comodines de subdominio', () => {
+    const origins = ['https://*.dominio.com']
+    expect(isAllowedOrigin('https://sub.dominio.com', origins)).toBe(true)
+  })
+
+  it('rechaza origenes no permitidos', () => {
+    const origins = ['https://example.com']
+    expect(isAllowedOrigin('https://otro.com', origins)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- allow CORS origin patterns with wildcards
- document how to use `ALLOWED_ORIGINS` with `*` for subdomains
- provide `isAllowedOrigin` helper
- add unit tests for the helper