### PR TITLE
Fix CORS header duplication

### DIFF
--- a/task-management/controllers/auth/logoutController.js
+++ b/task-management/controllers/auth/logoutController.js
@@ -1,7 +1,5 @@
 const logout = async (req, res) => {
   try {
-    res.header('Access-Control-Allow-Origin', 'https://invexly.netlify.app')
-    res.header('Access-Control-Allow-Credentials', 'true')
 
     // Recuperamos el token desde cookies o desde el header Authorization
     const tokenFromCookie = req.cookies.token

--- a/task-management/controllers/auth/refreshTokenController.js
+++ b/task-management/controllers/auth/refreshTokenController.js
@@ -7,9 +7,7 @@ import User from '../../../models/user.js'
  * @param {import('express').Response} res - Respuesta HTTP.
  */
 const refreshTokenController = async (req, res) => {
-  // Cabeceras CORS para mantener coherencia en todas las respuestas
-  res.header('Access-Control-Allow-Origin', 'https://invexly.netlify.app')
-  res.header('Access-Control-Allow-Credentials', 'true')
+  // Las cabeceras CORS se gestionan mediante los middlewares globales
 
   const refreshTokenCookie = req.cookies.refreshToken
 

--- a/task-management/controllers/auth/registerController.js
+++ b/task-management/controllers/auth/registerController.js
@@ -5,8 +5,6 @@ import { sendEmail } from '../emails/emailController.js'
 
 const register = async (req, res) => {
   try {
-    res.header('Access-Control-Allow-Origin', 'https://invexly.netlify.app')
-    res.header('Access-Control-Allow-Credentials', 'true')
 
     const { username, email, password, profileImage } = req.body
 

--- a/task-management/controllers/auth/tokenController.js
+++ b/task-management/controllers/auth/tokenController.js
@@ -2,9 +2,7 @@ import jwt from 'jsonwebtoken'
 import User from '../../../models/user.js'
 
 const validateToken = async (req, res) => {
-  // Se añaden cabeceras CORS necesarias para Render y Netlify
-  res.header('Access-Control-Allow-Origin', 'https://invexly.netlify.app/')
-  res.header('Access-Control-Allow-Credentials', 'true')
+  // Las cabeceras CORS se gestionan mediante middlewares dedicados
 
   try {
     const token =


### PR DESCRIPTION
## Summary
- remove CORS headers from authentication controllers
- leave CORS handling to `corsMiddleware` and `handlePreflight`