### PR TITLE
Fix authRoutes.js import paths

### DIFF
--- a/task-management/routes/authRoutes.js
+++ b/task-management/routes/authRoutes.js
@@ -4,8 +4,8 @@ import multer from 'multer'
 import register from '../controllers/auth/registerController.js'
 import login from '../controllers/auth/loginController.js'
 import logout from '../controllers/auth/logoutController.js'
-import validateToken from '../security/jwt/tokenController.js'
-import refreshToken from '../security/jwt/refreshTokenController.js'
+import validateToken from '../security/jwt/controllers/tokenController.js'
+import refreshToken from '../security/jwt/controllers/refreshTokenController.js'
 import {
   getProfile,
   updateUsername,
@@ -14,8 +14,8 @@ import {
   updateAvatar
 } from '../controllers/user/profileController.js'
 
-import validateAuth from '../security/jwt/validateAuth.js'
-import authenticateToken from '../security/jwt/authenticateToken.js'
+import validateAuth from '../security/jwt/middlewares/validateAuth.js'
+import authenticateToken from '../security/jwt/middlewares/authenticateToken.js'
 
 const router = express.Router()
 


### PR DESCRIPTION
## Summary
- update JWT-related import paths in `authRoutes.js` to new controllers and middlewares locations

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e87771fe08320911bb9f8e8268940