### PR TITLE
Fix logger path in config modules

### DIFF
--- a/task-management/config/brevo.js
+++ b/task-management/config/brevo.js
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv'
 import Brevo from '@getbrevo/brevo'
-import logger from '../../../utils/winstonLogger/loggers.js'
+// Registro centralizado con Winston
+import logger from '../../utils/winstonLogger/loggers.js'
 
 dotenv.config()
 

--- a/task-management/config/cloudinary.js
+++ b/task-management/config/cloudinary.js
@@ -1,6 +1,7 @@
 import { v2 as cloudinary } from 'cloudinary'
 import dotenv from 'dotenv'
-import logger from '../../../utils/winstonLogger/loggers.js'
+// Registro centralizado con Winston
+import logger from '../../utils/winstonLogger/loggers.js'
 
 dotenv.config()
 

--- a/task-management/config/db.js
+++ b/task-management/config/db.js
@@ -3,7 +3,8 @@
 // =========================================
 
 import mongoose from 'mongoose'
-import logger from '../../../utils/winstonLogger/loggers.js'
+// Registro centralizado con Winston
+import logger from '../../utils/winstonLogger/loggers.js'
 
 const connectDB = async () => {
   try {


### PR DESCRIPTION
## Summary
- correct Winston logger import paths for config modules

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882511335b0832095c8da1dc803821c