### PR TITLE
Fix logger import in profile controller

### DIFF
--- a/task-management/controllers/user/profile/profileController.js
+++ b/task-management/controllers/user/profile/profileController.js
@@ -3,7 +3,7 @@ import {
   saveUser
 } from '../../../services/profileService/profileService.js'
 
-import { logger } from '../../../../utils/winstonLogger/loggers.js'
+import logger from '../../../../utils/winstonLogger/loggers.js'
 
 // Obtener perfil del usuario
 export const getProfile = async (req, res) => {


### PR DESCRIPTION
## Summary
- correct logger import to use default export

## Testing
- `npm run lint` *(fails: Cannot find package)*
- `npm test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68826f092c8c83209151b96fecfa0e99