### PR TITLE
fix: alinear orígenes permitidos entre CORS y preflight

### DIFF
--- a/task-management/security/cors/config/allowedOrigins.js
+++ b/task-management/security/cors/config/allowedOrigins.js
@@ -1,0 +1,34 @@
+const DEFAULT_ALLOWED_ORIGINS = ['https://invexly.netlify.app']
+
+/**
+ * Construye la lista final de orígenes permitidos para CORS y preflight.
+ * - Prioriza `ALLOWED_ORIGINS` (lista separada por comas).
+ * - Mantiene compatibilidad con `FRONTEND_URL` si está definido.
+ * - Si no existe configuración por entorno, utiliza un valor seguro por defecto.
+ *
+ * @returns {string[]} Lista de orígenes normalizados y sin duplicados.
+ */
+const getAllowedOrigins = () => {
+  const allowedOriginsFromEnv = (process.env.ALLOWED_ORIGINS || '')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean)
+
+  const legacyFrontendUrl = process.env.FRONTEND_URL?.trim()
+
+  const combinedOrigins = [
+    ...allowedOriginsFromEnv,
+    ...(legacyFrontendUrl ? [legacyFrontendUrl] : [])
+  ]
+
+  if (combinedOrigins.length === 0) {
+    return DEFAULT_ALLOWED_ORIGINS
+  }
+
+  return [...new Set(combinedOrigins)]
+}
+
+const allowedOrigins = getAllowedOrigins()
+
+export { getAllowedOrigins }
+export default allowedOrigins

--- a/task-management/security/cors/config/corsOptions.js
+++ b/task-management/security/cors/config/corsOptions.js
@@ -1,13 +1,15 @@
-const allowedOrigins = ['https://invexly.netlify.app']
+import allowedOrigins from './allowedOrigins.js'
 
 const corsOptions = {
   origin: (origin, callback) => {
     if (!origin) {
       return callback(null, true)
     }
+
     if (allowedOrigins.includes(origin)) {
       return callback(null, true)
     }
+
     return callback(new Error('No autorizado por CORS'))
   },
   credentials: true

--- a/task-management/security/preflight/handlePreflight.js
+++ b/task-management/security/preflight/handlePreflight.js
@@ -1,6 +1,5 @@
 import logger from '../../../utils/winstonLogger/loggers.js'
-
-const allowedOrigins = [process.env.FRONTEND_URL]
+import allowedOrigins from '../cors/config/allowedOrigins.js'
 
 const handlePreflight = (req, res, next) => {
   if (req.method === 'OPTIONS') {
@@ -31,7 +30,7 @@ const handlePreflight = (req, res, next) => {
     return res.sendStatus(204)
   }
 
-  next()
+  return next()
 }
 
 export default handlePreflight

--- a/test/security/corsPreflightAlignment.test.js
+++ b/test/security/corsPreflightAlignment.test.js
@@ -1,0 +1,81 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, it, expect, beforeEach } from 'vitest'
+import corsMiddleware from '../../task-management/security/cors/middlewares/corsMiddleware.js'
+import handlePreflight from '../../task-management/security/preflight/handlePreflight.js'
+import allowedOrigins from '../../task-management/security/cors/config/allowedOrigins.js'
+
+/**
+ * Crea una aplicación mínima para validar el comportamiento conjunto
+ * de CORS y preflight sin depender del resto del sistema.
+ *
+ * @returns {import('express').Express} Aplicación lista para test.
+ */
+const createTestApp = () => {
+  const app = express()
+
+  app.use(corsMiddleware)
+  app.use(handlePreflight)
+
+  app.get('/health', (req, res) => {
+    res.status(200).json({ ok: true })
+  })
+
+  app.use((error, req, res, next) => {
+    if (error?.message === 'No autorizado por CORS') {
+      return res.status(403).json({ message: error.message })
+    }
+
+    return next(error)
+  })
+
+  return app
+}
+
+describe('Alineación entre CORS y preflight', () => {
+  let app
+  const allowedOrigin = allowedOrigins[0]
+  const blockedOrigin = 'https://origen-no-permitido.example'
+
+  beforeEach(() => {
+    app = createTestApp()
+  })
+
+  it('debería permitir OPTIONS preflight y request real para origen autorizado', async () => {
+    const preflightResponse = await request(app)
+      .options('/health')
+      .set('Origin', allowedOrigin)
+      .set('Access-Control-Request-Method', 'GET')
+
+    expect(preflightResponse.status).toBe(204)
+    expect(preflightResponse.headers['access-control-allow-origin']).toBe(
+      allowedOrigin
+    )
+
+    const getResponse = await request(app)
+      .get('/health')
+      .set('Origin', allowedOrigin)
+
+    expect(getResponse.status).toBe(200)
+    expect(getResponse.headers['access-control-allow-origin']).toBe(
+      allowedOrigin
+    )
+  })
+
+  it('debería bloquear OPTIONS preflight y request real para origen no autorizado', async () => {
+    const preflightResponse = await request(app)
+      .options('/health')
+      .set('Origin', blockedOrigin)
+      .set('Access-Control-Request-Method', 'GET')
+
+    expect(preflightResponse.status).toBe(403)
+    expect(preflightResponse.body.message).toBe('No autorizado por CORS')
+
+    const getResponse = await request(app)
+      .get('/health')
+      .set('Origin', blockedOrigin)
+
+    expect(getResponse.status).toBe(403)
+    expect(getResponse.body.message).toBe('No autorizado por CORS')
+  })
+})


### PR DESCRIPTION
### Motivation
- Corregir la desalineación entre la lista de orígenes usada por el middleware `cors` y la comprobación de `OPTIONS` (preflight) para evitar que peticiones pasen o sean rechazadas de forma inconsistente.
- Evitar el uso de orígenes hardcodeados y mantener compatibilidad con la configuración por entorno existente (`ALLOWED_ORIGINS` y `FRONTEND_URL`).

### Description
- Se añadió `task-management/security/cors/config/allowedOrigins.js` como fuente única de verdad para orígenes permitidos, que prioriza `ALLOWED_ORIGINS` (CSV), fallbacks a `FRONTEND_URL` y un valor por defecto seguro.
- `task-management/security/cors/config/corsOptions.js` ahora importa y utiliza la lista centralizada `allowedOrigins` en lugar de un valor hardcodeado.
- `task-management/security/preflight/handlePreflight.js` fue actualizado para reutilizar la misma lista `allowedOrigins` eliminando la discrepancia entre preflight y CORS normal.
- Se añadió la prueba `test/security/corsPreflightAlignment.test.js` que valida `OPTIONS` (preflight) y una petición `GET` real tanto para orígenes permitidos como para orígenes bloqueados.

### Testing
- Se ejecutó el lint y formateo sobre los archivos cambiados con `npx eslint ...` y `npx prettier --write ...` y las correcciones se aplicaron; el linter pasó tras el formateo automático.
- Se ejecutó la suite de prueba específica con `npx vitest run test/security/corsPreflightAlignment.test.js` y la prueba añadida pasó (2/2 tests OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f34f29a48320b5955ef2e68a6503)