### PR TITLE
Fix CSRF middleware scope to match mounted /auth routes

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ import User from './models/user.js'
 import bcrypt from 'bcrypt'
 import cookieParser from 'cookie-parser'
 import csrfValidator from './task-management/security/csrfValidator/csrfValidator.js'
+import applyCsrfProtection from './task-management/security/csrfValidator/applyCsrfProtection.js'
 
 dotenv.config()
 
@@ -45,10 +46,7 @@ app.get('/api/token/csrf', csrfValidator, (req, res) => {
 // =====================================
 // Protección CSRF en rutas sensibles (solo en producción)
 // =====================================
-if (process.env.NODE_ENV === 'production') {
-  app.use(['/api/profile', '/api/user'], csrfValidator)
-  app.use('/auth/logout', csrfValidator)
-}
+applyCsrfProtection(app)
 
 // =====================================
 // Middleware para depurar cookies recibidas

--- a/task-management/security/csrfValidator/applyCsrfProtection.js
+++ b/task-management/security/csrfValidator/applyCsrfProtection.js
@@ -1,0 +1,22 @@
+import csrfValidator from './csrfValidator.js'
+
+/**
+ * Aplica la protección CSRF sobre rutas sensibles cuando el entorno es producción.
+ *
+ * @param {import('express').Express} app - Instancia de Express donde se registra la protección.
+ * @param {string} nodeEnv - Valor del entorno de ejecución.
+ * @returns {string[]} Rutas montadas con protección CSRF.
+ */
+const applyCsrfProtection = (app, nodeEnv = process.env.NODE_ENV) => {
+  // Definimos explícitamente las rutas reales que se encuentran montadas bajo /auth.
+  const protectedRoutes = ['/auth/profile', '/auth/logout']
+
+  // Solo endurecemos estas rutas en producción para mantener el comportamiento esperado en tests y desarrollo.
+  if (nodeEnv === 'production') {
+    app.use(protectedRoutes, csrfValidator)
+  }
+
+  return protectedRoutes
+}
+
+export default applyCsrfProtection

--- a/test/security/csrfProtectionRoutes.test.js
+++ b/test/security/csrfProtectionRoutes.test.js
@@ -1,0 +1,91 @@
+import express from 'express'
+import cookieParser from 'cookie-parser'
+import request from 'supertest'
+import { describe, it, expect } from 'vitest'
+import applyCsrfProtection from '../../task-management/security/csrfValidator/applyCsrfProtection.js'
+
+/**
+ * Construye una app mínima para validar el montaje de CSRF
+ * en el mismo prefijo que usa el router real (/auth).
+ *
+ * @returns {import('express').Express} Aplicación de prueba.
+ */
+const createProductionApp = () => {
+  const app = express()
+
+  // Parseamos cookies porque csrfValidator depende de req.cookies.
+  app.use(cookieParser())
+  // Parseamos JSON para aceptar requests de prueba sin ruido.
+  app.use(express.json())
+
+  applyCsrfProtection(app, 'production')
+
+  // Simulamos rutas sensibles reales bajo /auth.
+  app.put('/auth/profile/username', (req, res) => {
+    res.status(200).json({ ok: true })
+  })
+
+  app.post('/auth/logout', (req, res) => {
+    res.status(200).json({ ok: true })
+  })
+
+  // Simulamos una ruta legacy /api/profile para comprobar que no queda protegida por error.
+  app.post('/api/profile', (req, res) => {
+    res.status(200).json({ ok: true })
+  })
+
+  return app
+}
+
+/**
+ * Obtiene los patrones montados para el middleware csrfValidator.
+ *
+ * @param {import('express').Express} app - Aplicación de prueba.
+ * @returns {string[]} Lista serializada de regex montadas por Express.
+ */
+const getCsrfMountRegexList = (app) =>
+  app._router.stack
+    .filter((layer) => layer?.handle?.name === 'csrfValidator')
+    .map((layer) => String(layer.regexp))
+
+describe('Protección CSRF alineada con rutas reales montadas', () => {
+  it('debería montar CSRF sobre /auth/profile y /auth/logout en producción', () => {
+    const app = createProductionApp()
+    const mountedRegex = getCsrfMountRegexList(app)
+
+    expect(mountedRegex.some((entry) => entry.includes('auth\\/profile'))).toBe(
+      true
+    )
+    expect(mountedRegex.some((entry) => entry.includes('auth\\/logout'))).toBe(
+      true
+    )
+    expect(mountedRegex.some((entry) => entry.includes('api\\/profile'))).toBe(
+      false
+    )
+  })
+
+  it('debería bloquear requests mutantes sin token CSRF en rutas sensibles reales', async () => {
+    const app = createProductionApp()
+
+    const profileMutation = await request(app)
+      .put('/auth/profile/username')
+      .send({ username: 'attacker' })
+
+    expect(profileMutation.status).toBe(403)
+    expect(profileMutation.body.message).toBe('CSRF token inválido o ausente')
+
+    const logoutMutation = await request(app).post('/auth/logout')
+
+    expect(logoutMutation.status).toBe(403)
+    expect(logoutMutation.body.message).toBe('CSRF token inválido o ausente')
+  })
+
+  it('no debería bloquear rutas legacy fuera del scope CSRF configurado', async () => {
+    const app = createProductionApp()
+
+    const legacyRoute = await request(app).post('/api/profile').send({})
+
+    expect(legacyRoute.status).toBe(200)
+    expect(legacyRoute.body.ok).toBe(true)
+  })
+})


### PR DESCRIPTION
### Motivation
- Corregir un desajuste donde la protección CSRF se aplicaba sobre rutas `/api/...` que no existen en el router de autenticación, dejando rutas reales sensibles bajo `/auth/...` sin la política esperada en producción.
- Reducir el riesgo de mutaciones sin token CSRF contra endpoints sensibles como perfil y logout por la diferencia entre la ruta protegida y la ruta montada.

### Description
- Se extrae la lógica de aplicación de CSRF a un helper `applyCsrfProtection` en `task-management/security/csrfValidator/applyCsrfProtection.js` que configura explícitamente las rutas protegidas `['/auth/profile', '/auth/logout']` en producción.
- `app.js` deja de aplicar CSRF sobre `['/api/profile','/api/user']` y ahora invoca `applyCsrfProtection(app)` para alinear el ámbito del middleware con las rutas montadas.
- Se añade la suite de pruebas `test/security/csrfProtectionRoutes.test.js` que valida el montaje del middleware en el stack de Express, que mutaciones sin token en `/auth/profile` y `/auth/logout` devuelven `403`, y que una ruta legacy `/api/profile` queda fuera del scope CSRF.
- Se aplicó formateo con `prettier` y se corrigieron avisos de lint para mantener consistencia de estilo.

### Testing
- Ejecutado `npx eslint app.js task-management/security/csrfValidator/applyCsrfProtection.js test/security/csrfProtectionRoutes.test.js` y el lint pasó tras formateo; resultado OK.
- Ejecutado `npx vitest run test/security/csrfProtectionRoutes.test.js` y la suite de seguridad añadió 3 tests que pasaron correctamente (`3 passed`).
- Se verificó manualmente el `app._router.stack` en tests para asegurar que `csrfValidator` se monta sobre `auth\/profile` y `auth\/logout` y no sobre `api\/profile`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f4f389348320be3987b6f8407b9d)