### PR TITLE
fix: hashear contraseña en endpoint de actualización de perfil

### DIFF
--- a/task-management/controllers/user/profile/profileController.js
+++ b/task-management/controllers/user/profile/profileController.js
@@ -2,6 +2,7 @@ import {
   findUserById,
   saveUser
 } from '../../../services/profileService/profileService.js'
+import bcrypt from 'bcrypt'
 
 import logger from '../../../../utils/winstonLogger/loggers.js'
 
@@ -75,7 +76,9 @@ export const updatePassword = async (req, res) => {
       )
       return res.status(404).json({ message: 'Usuario no encontrado' })
     }
-    user.password = req.body.password
+    // Hashear la contraseña antes de persistir para evitar almacenamiento en texto plano.
+    const hashedPassword = await bcrypt.hash(req.body.password, 10)
+    user.password = hashedPassword
     await saveUser(user)
     logger.info(`Contraseña actualizada (ID: ${req.user.id})`)
     res.status(200).json({ message: 'Contraseña actualizada correctamente' })

--- a/test/unit/profileController.updatePassword.test.js
+++ b/test/unit/profileController.updatePassword.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const {
+  mockFindUserById,
+  mockSaveUser,
+  mockHash,
+  mockLoggerInfo,
+  mockLoggerWarn,
+  mockLoggerError
+} = vi.hoisted(() => ({
+  mockFindUserById: vi.fn(),
+  mockSaveUser: vi.fn(),
+  mockHash: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+  mockLoggerError: vi.fn()
+}))
+
+vi.mock(
+  '../../task-management/services/profileService/profileService.js',
+  () => ({
+    findUserById: mockFindUserById,
+    saveUser: mockSaveUser
+  })
+)
+
+vi.mock('bcrypt', () => ({
+  default: {
+    hash: mockHash
+  }
+}))
+
+vi.mock('../../utils/winstonLogger/loggers.js', () => ({
+  default: {
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
+    error: mockLoggerError
+  }
+}))
+
+import { updatePassword } from '../../task-management/controllers/user/profile/profileController.js'
+
+describe('updatePassword controller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('hashea la contraseña antes de guardar el usuario', async () => {
+    const user = { _id: 'user-id', password: 'old-password' }
+
+    mockFindUserById.mockResolvedValue(user)
+    mockHash.mockResolvedValue('$2b$10$hashedPasswordValue')
+    mockSaveUser.mockResolvedValue(user)
+
+    const req = {
+      user: { id: 'user-id' },
+      body: { password: 'NuevaClave123!' }
+    }
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn()
+    }
+
+    await updatePassword(req, res)
+
+    expect(mockHash).toHaveBeenCalledWith('NuevaClave123!', 10)
+    expect(user.password).toBe('$2b$10$hashedPasswordValue')
+    expect(mockSaveUser).toHaveBeenCalledWith(user)
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Contraseña actualizada correctamente'
+    })
+  })
+})


### PR DESCRIPTION
### Motivation
- Evitar el riesgo de persistir contraseñas en texto plano cuando el usuario actualiza su contraseña desde `/auth/profile/password` ya que el controlador asignaba `user.password = req.body.password` sin hashear.

### Description
- Se importó `bcrypt` y se reemplazó la asignación directa por `const hashedPassword = await bcrypt.hash(req.body.password, 10)` y se guarda el hash en `user.password` en `task-management/controllers/user/profile/profileController.js`.
- Se añadió una prueba unitaria aislada en `test/unit/profileController.updatePassword.test.js` que verifica que se llame a `bcrypt.hash`, que se persista el hash y que el controlador responda con `200` y el mensaje esperado.
- Se ajustaron formatos menores para pasar `prettier/eslint` en los archivos modificados.

### Testing
- Ejecutado `npx eslint task-management/controllers/user/profile/profileController.js test/unit/profileController.updatePassword.test.js` y los errores de estilo fueron corregidos satisfactoriamente.
- Ejecutado `npx vitest run test/unit/profileController.updatePassword.test.js` y la prueba unitaria añadida pasó (1 test green).
- No se añadieron pruebas de integración con MongoDB real; la cobertura automática valida el comportamiento del controlador de forma aislada.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f65c523c8320a93b0d2d30aef741)