### PR TITLE
Refactor CSRF: reemplaza `csurf` por middleware token-based con `csrf`

### DIFF
--- a/task-management/security/csrfValidator/csrfValidator.js
+++ b/task-management/security/csrfValidator/csrfValidator.js
@@ -1,14 +1,50 @@
-import csrf from 'csurf'
+import Tokens from 'csrf'
 import logger from '../../../utils/winstonLogger/loggers.js'
 
-const csrfProtection = csrf({
-  cookie: {
+// Instancia única para generar y validar tokens CSRF con secretos por cookie.
+const csrfTokens = new Tokens()
+const CSRF_SECRET_COOKIE_NAME = 'csrfSecret'
+const CSRF_HEADER_NAME = 'x-csrf-token'
+
+/**
+ * Obtiene el secreto CSRF actual desde cookies o crea uno nuevo.
+ *
+ * @param {import('express').Request} req - Solicitud HTTP entrante.
+ * @param {import('express').Response} res - Respuesta HTTP saliente.
+ * @returns {string | null} Secreto CSRF válido o null si no fue posible generarlo.
+ */
+const ensureCsrfSecret = (req, res) => {
+  const currentSecret = req.cookies?.[CSRF_SECRET_COOKIE_NAME]
+
+  // Reutilizamos el secreto existente para mantener estable el token por sesión.
+  if (typeof currentSecret === 'string' && currentSecret.length > 0) {
+    return currentSecret
+  }
+
+  // Generamos un nuevo secreto cuando no existe cookie previa.
+  const generatedSecret = csrfTokens.secretSync()
+  if (!generatedSecret) {
+    return null
+  }
+
+  // Persistimos el secreto en una cookie HttpOnly para evitar acceso desde JavaScript.
+  res.cookie(CSRF_SECRET_COOKIE_NAME, generatedSecret, {
     httpOnly: true,
     sameSite: 'Strict',
     secure: process.env.NODE_ENV === 'production'
-  }
-})
+  })
 
+  return generatedSecret
+}
+
+/**
+ * Middleware CSRF para rutas de emisión y validación de token.
+ *
+ * @param {import('express').Request} req - Solicitud HTTP entrante.
+ * @param {import('express').Response} res - Respuesta HTTP saliente.
+ * @param {import('express').NextFunction} next - Siguiente middleware.
+ * @returns {void}
+ */
 const csrfValidator = (req, res, next) => {
   if (!req.cookies) {
     logger.error('[CSRF] cookie-parser no está aplicado antes de csrfValidator')
@@ -17,18 +53,37 @@ const csrfValidator = (req, res, next) => {
       .json({ message: 'Error interno de configuración CSRF' })
   }
 
-  csrfProtection(req, res, (err) => {
-    if (err) {
-      logger.warn(`[CSRF] Token inválido o ausente: ${err.message}`, {
-        path: req.path,
-        ip: req.ip
-      })
-      return res.status(403).json({ message: 'CSRF token inválido o ausente' })
-    }
+  // Garantizamos que siempre exista un secreto para construir o validar tokens.
+  const csrfSecret = ensureCsrfSecret(req, res)
+  if (!csrfSecret) {
+    logger.error('[CSRF] No fue posible generar el secreto CSRF')
+    return res.status(500).json({ message: 'Error interno de configuración CSRF' })
+  }
 
-    logger.debug('[CSRF] Token verificado correctamente')
-    next()
-  })
+  // Exponemos la función req.csrfToken() para mantener compatibilidad con el resto de la app.
+  req.csrfToken = () => csrfTokens.create(csrfSecret)
+
+  const isMutationMethod = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)
+  if (!isMutationMethod) {
+    logger.debug('[CSRF] Método seguro detectado, no se valida token')
+    return next()
+  }
+
+  // Obtenemos el token enviado por header o por body para soportar clientes variados.
+  const sentToken = req.get(CSRF_HEADER_NAME) || req.body?._csrf
+  const isTokenValid =
+    typeof sentToken === 'string' && csrfTokens.verify(csrfSecret, sentToken)
+
+  if (!isTokenValid) {
+    logger.warn('[CSRF] Token inválido o ausente', {
+      path: req.path,
+      ip: req.ip
+    })
+    return res.status(403).json({ message: 'CSRF token inválido o ausente' })
+  }
+
+  logger.debug('[CSRF] Token verificado correctamente')
+  return next()
 }
 
 export default csrfValidator


### PR DESCRIPTION
### Motivation

- El middleware original dependía de `csurf` en tiempo de ejecución; la refactorización busca eliminar esa dependencia y tener control directo sobre la generación/validación de tokens.
- Mantener compatibilidad con las rutas existentes que llaman a `req.csrfToken()` mientras se mejora la claridad de la lógica de secretos y tokens.

### Description

- Sustituido el uso de `csurf` por la librería de primitives `csrf` (clase `Tokens`) y creado un middleware custom en `task-management/security/csrfValidator/csrfValidator.js`.
- Añadida la función `ensureCsrfSecret` que obtiene o genera un secreto CSRF persistido en cookie `HttpOnly` (`csrfSecret`) con `sameSite` y `secure` según entorno.
- Exposición de `req.csrfToken()` para mantener compatibilidad con el resto de la app, usando `csrfTokens.create(csrfSecret)` para generar tokens.
- Validación explícita para métodos mutantes (`POST`, `PUT`, `PATCH`, `DELETE`) leyendo token desde header `x-csrf-token` o `body._csrf` y retornando `403` con el mensaje existente en caso de token inválido/ausente.

### Testing

- Ejecutado `npm test -- test/security/csrfProtectionRoutes.test.js` y los tests relevantes pasaron: 3 tests aprobados.
- Ejecutado `npm run lint -- task-management/security/csrfValidator/csrfValidator.js` y el linter falló por problemas preexistentes de formato (CRLF/Prettier) en múltiples archivos del repositorio, no por la lógica introducida.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f880ee208320a96e6296644d78b9)