### PR TITLE
fix: unificar campo `profileImage` entre login y perfil

### DIFF
--- a/task-management/controllers/auth/loginController.js
+++ b/task-management/controllers/auth/loginController.js
@@ -68,7 +68,7 @@ const login = async (req, res, next) => {
       username: user.username,
       email: user.email,
       role: user.role,
-      profile: user.profileImage
+      profileImage: user.profileImage
     })
   } catch (error) {
     logger.error(

--- a/task-management/controllers/user/profile/profileController.js
+++ b/task-management/controllers/user/profile/profileController.js
@@ -18,7 +18,7 @@ export const getProfile = async (req, res) => {
     res.status(200).json({
       username: user.username,
       email: user.email,
-      avatar: user.avatar
+      profileImage: user.profileImage
     })
   } catch (error) {
     logger.error(`Error en getProfile: ${error.message}`)
@@ -36,7 +36,10 @@ export const updateAvatar = async (req, res) => {
       )
       return res.status(404).json({ message: 'Usuario no encontrado' })
     }
-    user.avatar = req.body.avatar
+    // Mantener un único campo persistente para la imagen de perfil.
+    const profileImage = req.body.profileImage ?? req.body.avatar
+
+    user.profileImage = profileImage
     await saveUser(user)
     logger.info(`Avatar actualizado (ID: ${req.user.id})`)
     res.status(200).json({ message: 'Avatar actualizado correctamente' })

--- a/test/unit/authProfileImageConsistency.test.js
+++ b/test/unit/authProfileImageConsistency.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const {
+  mockFindOne,
+  mockFindById,
+  mockJwtSign,
+  mockBcryptCompare,
+  mockVerifyToken,
+  mockLoggerInfo,
+  mockLoggerWarn,
+  mockLoggerError
+} = vi.hoisted(() => ({
+  mockFindOne: vi.fn(),
+  mockFindById: vi.fn(),
+  mockJwtSign: vi.fn(),
+  mockBcryptCompare: vi.fn(),
+  mockVerifyToken: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+  mockLoggerError: vi.fn()
+}))
+
+vi.mock('../../models/user.js', () => ({
+  default: {
+    findOne: mockFindOne,
+    findById: mockFindById
+  }
+}))
+
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    sign: mockJwtSign
+  }
+}))
+
+vi.mock('bcrypt', () => ({
+  default: {
+    compare: mockBcryptCompare
+  }
+}))
+
+vi.mock('../../task-management/security/jwt/helpers/token/verifyToken.js', () => ({
+  verifyToken: mockVerifyToken
+}))
+
+vi.mock('../../utils/winstonLogger/loggers.js', () => ({
+  default: {
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
+    error: mockLoggerError
+  }
+}))
+
+import login from '../../task-management/controllers/auth/loginController.js'
+import tokenController from '../../task-management/security/jwt/controllers/tokenController.js'
+
+describe('Consistencia profileImage en login y validate-token', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.JWT_SECRET = 'test-secret'
+    process.env.REFRESH_TOKEN_SECRET = 'test-refresh-secret'
+  })
+
+  it('login responde profileImage y no usa la clave legacy profile', async () => {
+    const user = {
+      _id: 'user-id',
+      password: 'hashed-password',
+      username: 'test-user',
+      email: 'test@example.com',
+      role: 'user',
+      profileImage: 'https://cdn.example.com/avatar.png'
+    }
+
+    mockFindOne.mockResolvedValue(user)
+    mockBcryptCompare.mockResolvedValue(true)
+    mockJwtSign.mockReturnValueOnce('access-token').mockReturnValueOnce('refresh-token')
+
+    const req = {
+      body: { email: 'test@example.com', password: 'Password123!' },
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'vitest' }
+    }
+
+    const res = {
+      cookie: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn()
+    }
+
+    await login(req, res, vi.fn())
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    const loginPayload = res.json.mock.calls[0][0]
+    expect(loginPayload.profileImage).toBe('https://cdn.example.com/avatar.png')
+    expect(loginPayload).not.toHaveProperty('profile')
+  })
+
+  it('validate-token responde user.profileImage', async () => {
+    mockVerifyToken.mockReturnValue({ id: 'user-id' })
+    mockFindById.mockReturnValue({
+      select: vi.fn().mockResolvedValue({
+        _id: 'user-id',
+        username: 'test-user',
+        email: 'test@example.com',
+        role: 'user',
+        profileImage: 'https://cdn.example.com/avatar.png'
+      })
+    })
+
+    const req = {
+      cookies: { token: 'valid-token' },
+      headers: {},
+      ip: '127.0.0.1',
+      originalUrl: '/auth/validate-token',
+      method: 'GET'
+    }
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() }
+
+    await tokenController(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({
+      user: {
+        id: 'user-id',
+        username: 'test-user',
+        email: 'test@example.com',
+        role: 'user',
+        profileImage: 'https://cdn.example.com/avatar.png'
+      }
+    })
+  })
+})

--- a/test/unit/profileController.avatarConsistency.test.js
+++ b/test/unit/profileController.avatarConsistency.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const {
+  mockFindUserById,
+  mockSaveUser,
+  mockLoggerInfo,
+  mockLoggerWarn,
+  mockLoggerError
+} = vi.hoisted(() => ({
+  mockFindUserById: vi.fn(),
+  mockSaveUser: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+  mockLoggerError: vi.fn()
+}))
+
+vi.mock('../../task-management/services/profileService/profileService.js', () => ({
+  findUserById: mockFindUserById,
+  saveUser: mockSaveUser
+}))
+
+vi.mock('../../utils/winstonLogger/loggers.js', () => ({
+  default: {
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
+    error: mockLoggerError
+  }
+}))
+
+import {
+  getProfile,
+  updateAvatar
+} from '../../task-management/controllers/user/profile/profileController.js'
+
+describe('profileController - consistencia de profileImage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('getProfile devuelve profileImage como campo canónico', async () => {
+    mockFindUserById.mockResolvedValue({
+      username: 'test-user',
+      email: 'test@example.com',
+      profileImage: 'https://cdn.example.com/avatar.png'
+    })
+
+    const req = { user: { id: 'user-id' } }
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() }
+
+    await getProfile(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({
+      username: 'test-user',
+      email: 'test@example.com',
+      profileImage: 'https://cdn.example.com/avatar.png'
+    })
+  })
+
+  it('updateAvatar persiste profileImage desde body.profileImage', async () => {
+    const user = { profileImage: '' }
+    mockFindUserById.mockResolvedValue(user)
+    mockSaveUser.mockResolvedValue(user)
+
+    const req = {
+      user: { id: 'user-id' },
+      body: { profileImage: 'https://cdn.example.com/new-avatar.png' }
+    }
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() }
+
+    await updateAvatar(req, res)
+
+    expect(user.profileImage).toBe('https://cdn.example.com/new-avatar.png')
+    expect(mockSaveUser).toHaveBeenCalledWith(user)
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+})


### PR DESCRIPTION
### Motivation
- El modelo de usuario ya usa `profileImage` pero los controladores y respuestas usaban `avatar` o `profile`, provocando inconsistencias al leer/guardar la imagen de perfil.
- Se busca un único campo canónico para asegurar persistencia y coherencia entre endpoints de autenticación y perfil.

### Description
- `getProfile` ahora devuelve `profileImage` en la respuesta en lugar de `avatar` (`task-management/controllers/user/profile/profileController.js`).
- `updateAvatar` persiste el valor en `user.profileImage` y acepta `body.profileImage` con fallback a `body.avatar` para compatibilidad con payloads legados.
- `login` ahora expone `profileImage` en la carga útil de respuesta en vez de la clave antigua (`profile`) (`task-management/controllers/auth/loginController.js`).
- Se añadieron pruebas unitarias que verifican la consistencia de lectura/escritura de `profileImage` en perfil y autenticación (`test/unit/profileController.avatarConsistency.test.js` y `test/unit/authProfileImageConsistency.test.js`).

### Testing
- Ejecuté unit tests con `npm test -- --run test/unit/profileController.avatarConsistency.test.js test/unit/authProfileImageConsistency.test.js` y ambos archivos unitarios pasaron: 4 tests OK.
- Intenté ejecutar la prueba de integración original (`test/integration/profileImageConsistency.test.js`) y falló en el entorno CI local debido a variables de entorno y servicios no configurados (faltaron `BREVO_API_KEY` y URI de MongoDB), por lo que esa integración quedó bloqueada por dependencias externas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0fb029c808320b14e94e356a4ca08)