### PR TITLE
Harden CORS origin handling for validate-token session restore

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,14 @@ const app = express()
 const port = process.env.PORT || 8080
 
 // =====================================
+// Configuración de proxy confiable
+// Necesario en producción para despliegues detrás de proxies
+// =====================================
+if (process.env.NODE_ENV === 'production') {
+  app.set('trust proxy', 1)
+}
+
+// =====================================
 // Middleware para parsear cookies
 // =====================================
 app.use(cookieParser())

--- a/task-management/security/cors/config/allowedOrigins.js
+++ b/task-management/security/cors/config/allowedOrigins.js
@@ -1,6 +1,31 @@
 const DEFAULT_ALLOWED_ORIGINS = ['https://invexly.netlify.app']
 
 /**
+ * Normaliza un origin para evitar fallos por diferencias de formato
+ * (por ejemplo, slash final o mayúsculas en el host).
+ *
+ * @param {string} rawOrigin - Valor de origin sin normalizar.
+ * @returns {string|null} Origin normalizado o null si no es válido.
+ */
+const normalizeOrigin = (rawOrigin) => {
+  if (typeof rawOrigin !== 'string') {
+    return null
+  }
+
+  const trimmedOrigin = rawOrigin.trim()
+  if (!trimmedOrigin) {
+    return null
+  }
+
+  try {
+    const parsedOrigin = new URL(trimmedOrigin)
+    return parsedOrigin.origin
+  } catch {
+    return null
+  }
+}
+
+/**
  * Construye la lista final de orígenes permitidos para CORS y preflight.
  * - Prioriza `ALLOWED_ORIGINS` (lista separada por comas).
  * - Mantiene compatibilidad con `FRONTEND_URL` si está definido.
@@ -8,13 +33,16 @@ const DEFAULT_ALLOWED_ORIGINS = ['https://invexly.netlify.app']
  *
  * @returns {string[]} Lista de orígenes normalizados y sin duplicados.
  */
-const getAllowedOrigins = () => {
-  const allowedOriginsFromEnv = (process.env.ALLOWED_ORIGINS || '')
+const getAllowedOrigins = (environment = process.env) => {
+  const allowedOriginsFromEnv = (environment.ALLOWED_ORIGINS || '')
     .split(',')
-    .map((origin) => origin.trim())
+    .map((origin) => normalizeOrigin(origin))
     .filter(Boolean)
 
-  const legacyFrontendUrl = process.env.FRONTEND_URL?.trim()
+  const legacyFrontendUrl = normalizeOrigin(environment.FRONTEND_URL)
+  const defaultOrigins = DEFAULT_ALLOWED_ORIGINS.map((origin) =>
+    normalizeOrigin(origin)
+  ).filter(Boolean)
 
   const combinedOrigins = [
     ...allowedOriginsFromEnv,
@@ -22,7 +50,7 @@ const getAllowedOrigins = () => {
   ]
 
   if (combinedOrigins.length === 0) {
-    return DEFAULT_ALLOWED_ORIGINS
+    return defaultOrigins
   }
 
   return [...new Set(combinedOrigins)]
@@ -31,4 +59,5 @@ const getAllowedOrigins = () => {
 const allowedOrigins = getAllowedOrigins()
 
 export { getAllowedOrigins }
+export { normalizeOrigin }
 export default allowedOrigins

--- a/task-management/security/cors/config/corsOptions.js
+++ b/task-management/security/cors/config/corsOptions.js
@@ -1,4 +1,4 @@
-import allowedOrigins from './allowedOrigins.js'
+import allowedOrigins, { normalizeOrigin } from './allowedOrigins.js'
 
 const corsOptions = {
   origin: (origin, callback) => {
@@ -6,7 +6,9 @@ const corsOptions = {
       return callback(null, true)
     }
 
-    if (allowedOrigins.includes(origin)) {
+    const normalizedOrigin = normalizeOrigin(origin)
+
+    if (normalizedOrigin && allowedOrigins.includes(normalizedOrigin)) {
       return callback(null, true)
     }
 

--- a/task-management/security/jwt/controllers/tokenController.js
+++ b/task-management/security/jwt/controllers/tokenController.js
@@ -6,6 +6,14 @@ import logger from '../../../../utils/winstonLogger/loggers.js'
  * Controlador que valida un access token y devuelve el usuario.
  */
 const tokenController = async (req, res) => {
+  const requestContext = {
+    ip: req.ip,
+    method: req.method,
+    origin: req.headers.origin || 'sin-origin',
+    hasTokenCookie: Boolean(req.cookies?.token),
+    hasAuthorizationHeader: Boolean(req.headers.authorization)
+  }
+
   try {
     const token =
       req.cookies.token ||
@@ -13,9 +21,9 @@ const tokenController = async (req, res) => {
 
     if (!token) {
       logger.warn('Access token no proporcionado', {
-        ip: req.ip,
+        ...requestContext,
         url: req.originalUrl,
-        method: req.method
+        status: 401
       })
 
       return res.status(401).json({ message: 'Token no proporcionado' })
@@ -26,8 +34,9 @@ const tokenController = async (req, res) => {
       decoded = verifyToken(token, process.env.JWT_SECRET)
     } catch (error) {
       logger.warn('Access token inválido', {
-        ip: req.ip,
+        ...requestContext,
         tokenSnippet: token.slice(0, 10) + '...',
+        status: error.statusCode || 500,
         errorMessage: error.message
       })
 
@@ -42,15 +51,18 @@ const tokenController = async (req, res) => {
 
     if (!user) {
       logger.warn('Usuario no encontrado al validar token', {
-        userId: decoded.id
+        ...requestContext,
+        userId: decoded.id,
+        status: 404
       })
 
       return res.status(404).json({ message: 'Usuario no encontrado' })
     }
 
     logger.info('Access token validado correctamente', {
+      ...requestContext,
       userId: user.id,
-      ip: req.ip
+      status: 200
     })
 
     return res.status(200).json({
@@ -64,6 +76,8 @@ const tokenController = async (req, res) => {
     })
   } catch (error) {
     logger.error('Error inesperado al validar access token', {
+      ...requestContext,
+      status: 500,
       message: error.message,
       stack: error.stack
     })

--- a/task-management/security/preflight/handlePreflight.js
+++ b/task-management/security/preflight/handlePreflight.js
@@ -1,13 +1,14 @@
 import logger from '../../../utils/winstonLogger/loggers.js'
-import allowedOrigins from '../cors/config/allowedOrigins.js'
+import allowedOrigins, { normalizeOrigin } from '../cors/config/allowedOrigins.js'
 
 const handlePreflight = (req, res, next) => {
   if (req.method === 'OPTIONS') {
-    const origin = req.headers.origin
+    const requestOrigin = req.headers.origin
+    const normalizedOrigin = normalizeOrigin(requestOrigin)
 
-    if (!allowedOrigins.includes(origin)) {
+    if (!normalizedOrigin || !allowedOrigins.includes(normalizedOrigin)) {
       logger.warn('Preflight rechazado: origen no permitido', {
-        origin,
+        origin: requestOrigin,
         ip: req.ip,
         method: req.method
       })
@@ -18,11 +19,11 @@ const handlePreflight = (req, res, next) => {
     }
 
     logger.info('Preflight permitido', {
-      origin,
+      origin: normalizedOrigin,
       method: req.method
     })
 
-    res.header('Access-Control-Allow-Origin', origin)
+    res.header('Access-Control-Allow-Origin', normalizedOrigin)
     res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE')
     res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization')
     res.header('Access-Control-Allow-Credentials', 'true')

--- a/test/security/allowedOriginsNormalization.test.js
+++ b/test/security/allowedOriginsNormalization.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { getAllowedOrigins, normalizeOrigin } from '../../task-management/security/cors/config/allowedOrigins.js'
+
+/**
+ * Este bloque valida que la normalización de orígenes sea robusta
+ * para configuraciones productivas con slash final o entradas inválidas.
+ */
+describe('Normalización de orígenes CORS', () => {
+  it('debería normalizar orígenes con slash final y deduplicar', () => {
+    const origins = getAllowedOrigins({
+      ALLOWED_ORIGINS:
+        'https://invexly.netlify.app/, https://INVEXLY.netlify.app, https://api.example.com/',
+      FRONTEND_URL: 'https://invexly.netlify.app/'
+    })
+
+    expect(origins).toEqual([
+      'https://invexly.netlify.app',
+      'https://api.example.com'
+    ])
+  })
+
+  it('debería ignorar orígenes inválidos y mantener el fallback seguro', () => {
+    const origins = getAllowedOrigins({
+      ALLOWED_ORIGINS: 'valor-no-url',
+      FRONTEND_URL: ''
+    })
+
+    expect(origins).toEqual(['https://invexly.netlify.app'])
+    expect(normalizeOrigin('https://invexly.netlify.app/')).toBe(
+      'https://invexly.netlify.app'
+    )
+  })
+})


### PR DESCRIPTION
### Motivation
- Resolver fallos en producción de la llamada `GET /auth/validate-token` relacionados con CORS, cookies y diferencias de formato en `ALLOWED_ORIGINS` que impedían la restauración de sesión del frontend.
- Facilitar diagnóstico de incidentes de sesión aportando contexto en logs y compatibilidad detrás de proxies/reverse-proxies en producción.

### Description
- Añadí un helper `normalizeOrigin` y adapté `getAllowedOrigins` para normalizar y deduplicar orígenes configurados, además de permitir inyección de `environment` para testabilidad (`task-management/security/cors/config/allowedOrigins.js`).
- Cambié la validación runtime de CORS para comparar contra el origin normalizado en `corsOptions` (`task-management/security/cors/config/corsOptions.js`).
- Alineé el handler de preflight (`OPTIONS`) para validar y devolver el `Access-Control-Allow-Origin` normalizado (`task-management/security/preflight/handlePreflight.js`).
- Mejoré los logs y contexto en el controlador de validación de token (`GET /auth/validate-token`) para incluir `origin`, presencia de cookie/header y estado final, facilitando diagnóstico (`task-management/security/jwt/controllers/tokenController.js`).
- Habilité `app.set('trust proxy', 1)` en producción para compatibilidad detrás de proxies (`app.js`).
- Añadí pruebas unitarias que validan normalización, deduplicación y fallback seguro de orígenes (`test/security/allowedOriginsNormalization.test.js`).

### Testing
- Ejecuté tests focalizados con `npx vitest run test/security/corsPreflightAlignment.test.js test/security/allowedOriginsNormalization.test.js` y ambos archivos pasaron (4 tests totales) ✅.
- Intenté `npm test -- --runInBand` que falló porque Vitest en este repo no reconoce `--runInBand` (error de CLI) ❌.
- Ejecuté la suite completa con `npm test` y la ejecución se detuvo por falta de `MONGO_URI` / configuración de Mongo en el entorno de CI local, lo que provocó errores de conexión en tests de integración (limitación de entorno, no del cambio) ⚠️.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1170688708320a0eccc675e25d6e9)