### PR TITLE
Fix 403 CSRF failures on cross-site logout/profile mutations

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,9 @@ import { sendEmail } from './task-management/controllers/emails/emailController.
 import User from './models/user.js'
 import bcrypt from 'bcrypt'
 import cookieParser from 'cookie-parser'
-import csrfValidator from './task-management/security/csrfValidator/csrfValidator.js'
+import csrfValidator, {
+  getCsrfTokenCookieOptions
+} from './task-management/security/csrfValidator/csrfValidator.js'
 import applyCsrfProtection from './task-management/security/csrfValidator/applyCsrfProtection.js'
 
 dotenv.config()
@@ -48,7 +50,7 @@ applyMiddlewares(app) // Aplica middlewares generales
 // =====================================
 app.get('/api/token/csrf', csrfValidator, (req, res) => {
   const token = req.csrfToken()
-  res.cookie('XSRF-TOKEN', token)
+  res.cookie('XSRF-TOKEN', token, getCsrfTokenCookieOptions())
   console.log('[CSRF] Token CSRF generado y enviado')
   res.status(200).json({ message: 'Token CSRF enviado correctamente' })
 })

--- a/task-management/security/csrfValidator/csrfValidator.js
+++ b/task-management/security/csrfValidator/csrfValidator.js
@@ -7,6 +7,42 @@ const CSRF_SECRET_COOKIE_NAME = 'csrfSecret'
 const CSRF_HEADER_NAME = 'x-csrf-token'
 
 /**
+ * Define opciones de cookie compatibles con flujos same-site y cross-site.
+ *
+ * En producción forzamos `SameSite=None` para que navegadores modernos envíen
+ * cookies en requests con credenciales desde dominios distintos (frontend/backend).
+ *
+ * @returns {{ httpOnly: boolean, sameSite: 'none' | 'strict', secure: boolean }}
+ */
+const getCsrfSecretCookieOptions = () => {
+  const isProduction = process.env.NODE_ENV === 'production'
+
+  return {
+    httpOnly: true,
+    sameSite: isProduction ? 'none' : 'strict',
+    secure: isProduction
+  }
+}
+
+/**
+ * Define opciones de cookie para exponer el token CSRF al cliente.
+ *
+ * El token debe ser legible por JavaScript para enviarlo en `x-csrf-token`.
+ * En producción usamos `SameSite=None` para soportar frontend en otro dominio.
+ *
+ * @returns {{ httpOnly: boolean, sameSite: 'none' | 'strict', secure: boolean }}
+ */
+const getCsrfTokenCookieOptions = () => {
+  const isProduction = process.env.NODE_ENV === 'production'
+
+  return {
+    httpOnly: false,
+    sameSite: isProduction ? 'none' : 'strict',
+    secure: isProduction
+  }
+}
+
+/**
  * Obtiene el secreto CSRF actual desde cookies o crea uno nuevo.
  *
  * @param {import('express').Request} req - Solicitud HTTP entrante.
@@ -28,11 +64,11 @@ const ensureCsrfSecret = (req, res) => {
   }
 
   // Persistimos el secreto en una cookie HttpOnly para evitar acceso desde JavaScript.
-  res.cookie(CSRF_SECRET_COOKIE_NAME, generatedSecret, {
-    httpOnly: true,
-    sameSite: 'Strict',
-    secure: process.env.NODE_ENV === 'production'
-  })
+  res.cookie(
+    CSRF_SECRET_COOKIE_NAME,
+    generatedSecret,
+    getCsrfSecretCookieOptions()
+  )
 
   return generatedSecret
 }
@@ -57,13 +93,17 @@ const csrfValidator = (req, res, next) => {
   const csrfSecret = ensureCsrfSecret(req, res)
   if (!csrfSecret) {
     logger.error('[CSRF] No fue posible generar el secreto CSRF')
-    return res.status(500).json({ message: 'Error interno de configuración CSRF' })
+    return res
+      .status(500)
+      .json({ message: 'Error interno de configuración CSRF' })
   }
 
   // Exponemos la función req.csrfToken() para mantener compatibilidad con el resto de la app.
   req.csrfToken = () => csrfTokens.create(csrfSecret)
 
-  const isMutationMethod = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)
+  const isMutationMethod = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(
+    req.method
+  )
   if (!isMutationMethod) {
     logger.debug('[CSRF] Método seguro detectado, no se valida token')
     return next()
@@ -87,3 +127,4 @@ const csrfValidator = (req, res, next) => {
 }
 
 export default csrfValidator
+export { getCsrfSecretCookieOptions, getCsrfTokenCookieOptions }

--- a/test/security/csrfCookieOptions.test.js
+++ b/test/security/csrfCookieOptions.test.js
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  getCsrfSecretCookieOptions,
+  getCsrfTokenCookieOptions
+} from '../../task-management/security/csrfValidator/csrfValidator.js'
+
+/**
+ * Restaura NODE_ENV entre pruebas para evitar contaminación global.
+ */
+afterEach(() => {
+  delete process.env.NODE_ENV
+})
+
+describe('Opciones de cookies CSRF', () => {
+  it('debería usar SameSite=None y secure en producción para soportar front cross-site', () => {
+    process.env.NODE_ENV = 'production'
+
+    const secretOptions = getCsrfSecretCookieOptions()
+    const tokenOptions = getCsrfTokenCookieOptions()
+
+    expect(secretOptions).toMatchObject({
+      httpOnly: true,
+      sameSite: 'none',
+      secure: true
+    })
+
+    expect(tokenOptions).toMatchObject({
+      httpOnly: false,
+      sameSite: 'none',
+      secure: true
+    })
+  })
+
+  it('debería mantener SameSite=Strict en desarrollo para entorno local', () => {
+    process.env.NODE_ENV = 'development'
+
+    const secretOptions = getCsrfSecretCookieOptions()
+    const tokenOptions = getCsrfTokenCookieOptions()
+
+    expect(secretOptions).toMatchObject({
+      httpOnly: true,
+      sameSite: 'strict',
+      secure: false
+    })
+
+    expect(tokenOptions).toMatchObject({
+      httpOnly: false,
+      sameSite: 'strict',
+      secure: false
+    })
+  })
+})


### PR DESCRIPTION
### Motivation
- Frontend observed HTTP 403 on `/auth/logout` and `/profile/avatar` because the CSRF secret cookie was emitted with `SameSite=Strict`, preventing the browser from sending the cookie on cross-site authenticated requests. 
- The goal is to ensure CSRF cookies are sent when frontend and backend live on different origins while keeping safe defaults for local development.

### Description
- Added environment-aware cookie option helpers `getCsrfSecretCookieOptions` and `getCsrfTokenCookieOptions` to `task-management/security/csrfValidator/csrfValidator.js` and exported them. 
- Persist the CSRF secret using `getCsrfSecretCookieOptions()` so production uses `SameSite=None` and `secure: true`, and development keeps `SameSite=Strict`. 
- Expose the CSRF token cookie `XSRF-TOKEN` with `getCsrfTokenCookieOptions()` (non-HttpOnly so the frontend can read and send `x-csrf-token`), and wired that option into the `/api/token/csrf` route in `app.js`. 
- Added tests `test/security/csrfCookieOptions.test.js` to validate cookie options for `production` and `development`, and kept the existing CSRF protection tests for route behavior.

### Testing
- Ran unit/integration tests with `npx vitest run test/security/csrfProtectionRoutes.test.js test/security/csrfCookieOptions.test.js` and all tests passed. 
- Ran lint/format and fixed style issues with `npx prettier --write` and `npx eslint` until no blocking errors remained. 
- Verified changed files were committed and a concise PR description was prepared reflecting the above validation steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a122c01c208320b75e5ab2251cefca)