### PR TITLE
Enhance CSRF validator: header aliases, trusted-origin bypass, cookie options and tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,9 @@ import { sendEmail } from './task-management/controllers/emails/emailController.
 import User from './models/user.js'
 import bcrypt from 'bcrypt'
 import cookieParser from 'cookie-parser'
-import csrfValidator from './task-management/security/csrfValidator/csrfValidator.js'
+import csrfValidator, {
+  getCsrfTokenCookieOptions
+} from './task-management/security/csrfValidator/csrfValidator.js'
 import applyCsrfProtection from './task-management/security/csrfValidator/applyCsrfProtection.js'
 
 dotenv.config()
@@ -48,7 +50,7 @@ applyMiddlewares(app) // Aplica middlewares generales
 // =====================================
 app.get('/api/token/csrf', csrfValidator, (req, res) => {
   const token = req.csrfToken()
-  res.cookie('XSRF-TOKEN', token)
+  res.cookie('XSRF-TOKEN', token, getCsrfTokenCookieOptions())
   console.log('[CSRF] Token CSRF generado y enviado')
   res.status(200).json({ message: 'Token CSRF enviado correctamente' })
 })

--- a/task-management/security/csrfValidator/csrfValidator.js
+++ b/task-management/security/csrfValidator/csrfValidator.js
@@ -1,10 +1,117 @@
 import Tokens from 'csrf'
 import logger from '../../../utils/winstonLogger/loggers.js'
+import allowedOrigins, {
+  normalizeOrigin
+} from '../cors/config/allowedOrigins.js'
 
 // Instancia única para generar y validar tokens CSRF con secretos por cookie.
 const csrfTokens = new Tokens()
 const CSRF_SECRET_COOKIE_NAME = 'csrfSecret'
-const CSRF_HEADER_NAME = 'x-csrf-token'
+const CSRF_HEADER_NAMES = ['x-csrf-token', 'x-xsrf-token', 'csrf-token']
+
+/**
+ * Define opciones de cookie compatibles con flujos same-site y cross-site.
+ *
+ * En producción forzamos `SameSite=None` para que navegadores modernos envíen
+ * cookies en requests con credenciales desde dominios distintos (frontend/backend).
+ *
+ * @returns {{ httpOnly: boolean, sameSite: 'none' | 'strict', secure: boolean }}
+ */
+const getCsrfSecretCookieOptions = () => {
+  const isProduction = process.env.NODE_ENV === 'production'
+
+  return {
+    httpOnly: true,
+    sameSite: isProduction ? 'none' : 'strict',
+    secure: isProduction
+  }
+}
+
+/**
+ * Define opciones de cookie para exponer el token CSRF al cliente.
+ *
+ * El token debe ser legible por JavaScript para enviarlo en `x-csrf-token`.
+ * En producción usamos `SameSite=None` para soportar frontend en otro dominio.
+ *
+ * @returns {{ httpOnly: boolean, sameSite: 'none' | 'strict', secure: boolean }}
+ */
+const getCsrfTokenCookieOptions = () => {
+  const isProduction = process.env.NODE_ENV === 'production'
+
+  return {
+    httpOnly: false,
+    sameSite: isProduction ? 'none' : 'strict',
+    secure: isProduction
+  }
+}
+
+/**
+ * Resuelve el origin de la request a partir de `Origin` o `Referer`.
+ *
+ * @param {import('express').Request} req - Solicitud HTTP entrante.
+ * @returns {string | null} Origin normalizado o null cuando no existe.
+ */
+const getRequestOrigin = (req) => {
+  const explicitOrigin = normalizeOrigin(req.get('origin'))
+  if (explicitOrigin) {
+    return explicitOrigin
+  }
+
+  const refererHeader = req.get('referer')
+  if (typeof refererHeader !== 'string' || refererHeader.trim().length === 0) {
+    return null
+  }
+
+  try {
+    const refererOrigin = new URL(refererHeader).origin
+    return normalizeOrigin(refererOrigin)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Determina si la request viene desde un origin confiable.
+ *
+ * Esto reduce falsos positivos de CSRF en flujos SPA cross-site donde el
+ * frontend está explícitamente permitido por CORS.
+ *
+ * @param {import('express').Request} req - Solicitud HTTP entrante.
+ * @returns {boolean} true si el origin está permitido; false en otro caso.
+ */
+const isTrustedOriginRequest = (req) => {
+  const requestOrigin = getRequestOrigin(req)
+
+  return Boolean(requestOrigin && allowedOrigins.includes(requestOrigin))
+}
+
+/**
+ * Obtiene el token CSRF desde headers soportados o desde el body.
+ *
+ * Aceptamos múltiples nombres para ser compatibles con clientes comunes
+ * (por ejemplo Axios usa `X-XSRF-TOKEN` por defecto).
+ *
+ * @param {import('express').Request} req - Solicitud HTTP entrante.
+ * @returns {string | undefined} Token CSRF recibido por el cliente.
+ */
+const getCsrfTokenFromRequest = (req) => {
+  for (const headerName of CSRF_HEADER_NAMES) {
+    const tokenFromHeader = req.get(headerName)
+
+    if (
+      typeof tokenFromHeader === 'string' &&
+      tokenFromHeader.trim().length > 0
+    ) {
+      return tokenFromHeader
+    }
+  }
+
+  if (typeof req.body?._csrf === 'string' && req.body._csrf.trim().length > 0) {
+    return req.body._csrf
+  }
+
+  return undefined
+}
 
 /**
  * Obtiene el secreto CSRF actual desde cookies o crea uno nuevo.
@@ -28,11 +135,11 @@ const ensureCsrfSecret = (req, res) => {
   }
 
   // Persistimos el secreto en una cookie HttpOnly para evitar acceso desde JavaScript.
-  res.cookie(CSRF_SECRET_COOKIE_NAME, generatedSecret, {
-    httpOnly: true,
-    sameSite: 'Strict',
-    secure: process.env.NODE_ENV === 'production'
-  })
+  res.cookie(
+    CSRF_SECRET_COOKIE_NAME,
+    generatedSecret,
+    getCsrfSecretCookieOptions()
+  )
 
   return generatedSecret
 }
@@ -57,20 +164,31 @@ const csrfValidator = (req, res, next) => {
   const csrfSecret = ensureCsrfSecret(req, res)
   if (!csrfSecret) {
     logger.error('[CSRF] No fue posible generar el secreto CSRF')
-    return res.status(500).json({ message: 'Error interno de configuración CSRF' })
+    return res
+      .status(500)
+      .json({ message: 'Error interno de configuración CSRF' })
   }
 
   // Exponemos la función req.csrfToken() para mantener compatibilidad con el resto de la app.
   req.csrfToken = () => csrfTokens.create(csrfSecret)
 
-  const isMutationMethod = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)
+  const isMutationMethod = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(
+    req.method
+  )
   if (!isMutationMethod) {
     logger.debug('[CSRF] Método seguro detectado, no se valida token')
     return next()
   }
 
-  // Obtenemos el token enviado por header o por body para soportar clientes variados.
-  const sentToken = req.get(CSRF_HEADER_NAME) || req.body?._csrf
+  // Permitimos mutaciones desde origins explícitamente autorizados para evitar
+  // bloqueos en SPAs cross-site que ya pasan por validación estricta de CORS.
+  if (isTrustedOriginRequest(req)) {
+    logger.debug('[CSRF] Request mutante permitida por origin confiable')
+    return next()
+  }
+
+  // Obtenemos el token enviado por headers compatibles o por body.
+  const sentToken = getCsrfTokenFromRequest(req)
   const isTokenValid =
     typeof sentToken === 'string' && csrfTokens.verify(csrfSecret, sentToken)
 
@@ -87,3 +205,10 @@ const csrfValidator = (req, res, next) => {
 }
 
 export default csrfValidator
+export {
+  getCsrfSecretCookieOptions,
+  getCsrfTokenCookieOptions,
+  getCsrfTokenFromRequest,
+  getRequestOrigin,
+  isTrustedOriginRequest
+}

--- a/test/security/csrfCookieOptions.test.js
+++ b/test/security/csrfCookieOptions.test.js
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  getCsrfSecretCookieOptions,
+  getCsrfTokenCookieOptions
+} from '../../task-management/security/csrfValidator/csrfValidator.js'
+
+/**
+ * Restaura NODE_ENV entre pruebas para evitar contaminación global.
+ */
+afterEach(() => {
+  delete process.env.NODE_ENV
+})
+
+describe('Opciones de cookies CSRF', () => {
+  it('debería usar SameSite=None y secure en producción para soportar front cross-site', () => {
+    process.env.NODE_ENV = 'production'
+
+    const secretOptions = getCsrfSecretCookieOptions()
+    const tokenOptions = getCsrfTokenCookieOptions()
+
+    expect(secretOptions).toMatchObject({
+      httpOnly: true,
+      sameSite: 'none',
+      secure: true
+    })
+
+    expect(tokenOptions).toMatchObject({
+      httpOnly: false,
+      sameSite: 'none',
+      secure: true
+    })
+  })
+
+  it('debería mantener SameSite=Strict en desarrollo para entorno local', () => {
+    process.env.NODE_ENV = 'development'
+
+    const secretOptions = getCsrfSecretCookieOptions()
+    const tokenOptions = getCsrfTokenCookieOptions()
+
+    expect(secretOptions).toMatchObject({
+      httpOnly: true,
+      sameSite: 'strict',
+      secure: false
+    })
+
+    expect(tokenOptions).toMatchObject({
+      httpOnly: false,
+      sameSite: 'strict',
+      secure: false
+    })
+  })
+})

--- a/test/security/csrfHeaderAliases.test.js
+++ b/test/security/csrfHeaderAliases.test.js
@@ -1,0 +1,92 @@
+import cookieParser from 'cookie-parser'
+import express from 'express'
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+import csrfValidator from '../../task-management/security/csrfValidator/csrfValidator.js'
+
+/**
+ * Crea una aplicación mínima para validar compatibilidad
+ * de aliases de cabeceras CSRF en requests mutantes.
+ *
+ * @returns {import('express').Express} Aplicación Express para pruebas.
+ */
+const createCsrfAliasTestApp = () => {
+  const app = express()
+
+  // Registramos parsers requeridos por el middleware CSRF.
+  app.use(cookieParser())
+  app.use(express.json())
+
+  // Exponemos una ruta para emitir token usando la misma lógica real.
+  app.get('/api/token/csrf', csrfValidator, (req, res) => {
+    res.status(200).json({ token: req.csrfToken() })
+  })
+
+  // Simulamos la ruta sensible observada desde frontend.
+  app.put('/auth/profile/avatar', csrfValidator, (req, res) => {
+    res.status(200).json({ ok: true })
+  })
+
+  return app
+}
+
+describe('Compatibilidad de headers CSRF', () => {
+  it('debería aceptar x-csrf-token y x-xsrf-token en mutaciones protegidas', async () => {
+    const app = createCsrfAliasTestApp()
+    const agent = request.agent(app)
+
+    const tokenResponse = await agent.get('/api/token/csrf')
+    const { token } = tokenResponse.body
+
+    const withCsrfHeader = await agent
+      .put('/auth/profile/avatar')
+      .set('x-csrf-token', token)
+      .send({ profileImage: 'https://cdn.example.com/new-avatar.png' })
+
+    expect(withCsrfHeader.status).toBe(200)
+    expect(withCsrfHeader.body.ok).toBe(true)
+
+    const withXsrfHeader = await agent
+      .put('/auth/profile/avatar')
+      .set('x-xsrf-token', token)
+      .send({ profileImage: 'https://cdn.example.com/new-avatar.png' })
+
+    expect(withXsrfHeader.status).toBe(200)
+    expect(withXsrfHeader.body.ok).toBe(true)
+  })
+
+  it('debería rechazar mutaciones cuando el token no está presente', async () => {
+    const app = createCsrfAliasTestApp()
+
+    const response = await request(app)
+      .put('/auth/profile/avatar')
+      .send({ profileImage: 'https://cdn.example.com/new-avatar.png' })
+
+    expect(response.status).toBe(403)
+    expect(response.body.message).toBe('CSRF token inválido o ausente')
+  })
+
+  it('debería permitir mutaciones sin token CSRF cuando el origin está autorizado', async () => {
+    const app = createCsrfAliasTestApp()
+
+    const response = await request(app)
+      .put('/auth/profile/avatar')
+      .set('Origin', 'https://invexly.netlify.app')
+      .send({ profileImage: 'https://cdn.example.com/new-avatar.png' })
+
+    expect(response.status).toBe(200)
+    expect(response.body.ok).toBe(true)
+  })
+
+  it('debería rechazar mutaciones sin token cuando el origin no está autorizado', async () => {
+    const app = createCsrfAliasTestApp()
+
+    const response = await request(app)
+      .put('/auth/profile/avatar')
+      .set('Origin', 'https://malicious.example')
+      .send({ profileImage: 'https://cdn.example.com/new-avatar.png' })
+
+    expect(response.status).toBe(403)
+    expect(response.body.message).toBe('CSRF token inválido o ausente')
+  })
+})


### PR DESCRIPTION
### Motivation
- Improve CSRF handling for SPAs and cross-site frontends by supporting common header aliases and flexible cookie options.
- Avoid false CSRF rejections for requests originating from allowed CORS origins by allowing trusted-origin bypass when appropriate.
- Provide utilities to generate consistent cookie options and make CSRF behavior easier to test.

### Description
- Refactor `task-management/security/csrfValidator/csrfValidator.js` to add `getCsrfSecretCookieOptions`, `getCsrfTokenCookieOptions`, support multiple header names (`x-csrf-token`, `x-xsrf-token`, `csrf-token`), resolve request origin, check `allowedOrigins`, and export helper functions used by tests and `app.js`.
- Update `app.js` to set the `XSRF-TOKEN` response cookie using `getCsrfTokenCookieOptions()` when issuing CSRF tokens.
- Add tests `test/security/csrfCookieOptions.test.js` and `test/security/csrfHeaderAliases.test.js` to validate cookie option behavior across environments and to verify header alias acceptance and origin-based bypass with `supertest`.

### Testing
- Ran unit tests with `vitest`, including the new `csrfCookieOptions.test.js` and `csrfHeaderAliases.test.js`, and they passed.
- Executed the `supertest`-based integration checks in `csrfHeaderAliases.test.js` which validated token issuance, header alias acceptance, origin-authorized bypass, and those checks passed.
- Verified that the added exports and changes did not break other automated tests and the full test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a122c01c208320b75e5ab2251cefca)