### PR TITLE
Improve CSRF token flow to fix 403 on avatar update

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ import User from './models/user.js'
 import bcrypt from 'bcrypt'
 import cookieParser from 'cookie-parser'
 import csrfValidator, {
-  getCsrfTokenCookieOptions
+  issueCsrfToken
 } from './task-management/security/csrfValidator/csrfValidator.js'
 import applyCsrfProtection from './task-management/security/csrfValidator/applyCsrfProtection.js'
 
@@ -49,10 +49,19 @@ applyMiddlewares(app) // Aplica middlewares generales
 // Ruta pública para obtener token CSRF
 // =====================================
 app.get('/api/token/csrf', csrfValidator, (req, res) => {
-  const token = req.csrfToken()
-  res.cookie('XSRF-TOKEN', token, getCsrfTokenCookieOptions())
+  const token = issueCsrfToken(req, res)
+
+  if (!token) {
+    return res
+      .status(500)
+      .json({ message: 'No fue posible emitir el token CSRF' })
+  }
+
   console.log('[CSRF] Token CSRF generado y enviado')
-  res.status(200).json({ message: 'Token CSRF enviado correctamente' })
+  return res.status(200).json({
+    message: 'Token CSRF enviado correctamente',
+    token
+  })
 })
 
 // =====================================

--- a/task-management/security/csrfValidator/csrfValidator.js
+++ b/task-management/security/csrfValidator/csrfValidator.js
@@ -5,6 +5,8 @@ import logger from '../../../utils/winstonLogger/loggers.js'
 const csrfTokens = new Tokens()
 const CSRF_SECRET_COOKIE_NAME = 'csrfSecret'
 const CSRF_HEADER_NAME = 'x-csrf-token'
+const XSRF_HEADER_NAME = 'x-xsrf-token'
+const CSRF_TOKEN_COOKIE_NAME = 'XSRF-TOKEN'
 
 /**
  * Define opciones de cookie compatibles con flujos same-site y cross-site.
@@ -74,6 +76,25 @@ const ensureCsrfSecret = (req, res) => {
 }
 
 /**
+ * Genera y envía un token CSRF legible por JavaScript para clientes SPA.
+ *
+ * @param {import('express').Request} req - Solicitud HTTP entrante.
+ * @param {import('express').Response} res - Respuesta HTTP saliente.
+ * @returns {string | null} Token CSRF emitido o null si no fue posible.
+ */
+const issueCsrfToken = (req, res) => {
+  const csrfSecret = ensureCsrfSecret(req, res)
+  if (!csrfSecret) {
+    return null
+  }
+
+  const token = csrfTokens.create(csrfSecret)
+  res.cookie(CSRF_TOKEN_COOKIE_NAME, token, getCsrfTokenCookieOptions())
+
+  return token
+}
+
+/**
  * Middleware CSRF para rutas de emisión y validación de token.
  *
  * @param {import('express').Request} req - Solicitud HTTP entrante.
@@ -110,7 +131,8 @@ const csrfValidator = (req, res, next) => {
   }
 
   // Obtenemos el token enviado por header o por body para soportar clientes variados.
-  const sentToken = req.get(CSRF_HEADER_NAME) || req.body?._csrf
+  const sentToken =
+    req.get(CSRF_HEADER_NAME) || req.get(XSRF_HEADER_NAME) || req.body?._csrf
   const isTokenValid =
     typeof sentToken === 'string' && csrfTokens.verify(csrfSecret, sentToken)
 
@@ -127,4 +149,9 @@ const csrfValidator = (req, res, next) => {
 }
 
 export default csrfValidator
-export { getCsrfSecretCookieOptions, getCsrfTokenCookieOptions }
+export {
+  getCsrfSecretCookieOptions,
+  getCsrfTokenCookieOptions,
+  issueCsrfToken,
+  CSRF_TOKEN_COOKIE_NAME
+}

--- a/task-management/security/jwt/controllers/refreshTokenController.js
+++ b/task-management/security/jwt/controllers/refreshTokenController.js
@@ -2,6 +2,7 @@ import User from '../../../../models/user.js'
 import { signAndSendAccessToken } from '../helpers/token/signAndSendAccessToken.js'
 import { verifyToken } from '../helpers/token/verifyToken.js'
 import logger from '../../../../utils/winstonLogger/loggers.js'
+import { issueCsrfToken } from '../../csrfValidator/csrfValidator.js'
 
 /**
  * Controlador que renueva el token de acceso utilizando el refresh token.
@@ -44,6 +45,7 @@ const refreshTokenController = async (req, res) => {
     }
 
     const accessToken = signAndSendAccessToken(res, user.id, '1h')
+    issueCsrfToken(req, res)
 
     logger.info('Token de acceso renovado correctamente', {
       userId: user.id,

--- a/test/security/csrfValidatorCompatibility.test.js
+++ b/test/security/csrfValidatorCompatibility.test.js
@@ -1,0 +1,68 @@
+import express from 'express'
+import cookieParser from 'cookie-parser'
+import request from 'supertest'
+import { describe, it, expect } from 'vitest'
+import csrfValidator, {
+  issueCsrfToken,
+  CSRF_TOKEN_COOKIE_NAME
+} from '../../task-management/security/csrfValidator/csrfValidator.js'
+
+/**
+ * Construye una app mínima para comprobar compatibilidad CSRF
+ * con clientes axios y flujo de emisión de token.
+ *
+ * @returns {import('express').Express} Aplicación de pruebas.
+ */
+const createCsrfApp = () => {
+  const app = express()
+
+  app.use(cookieParser())
+  app.use(express.json())
+
+  app.get('/token', csrfValidator, (req, res) => {
+    const token = issueCsrfToken(req, res)
+    return res.status(200).json({ token })
+  })
+
+  app.put('/profile', csrfValidator, (req, res) => {
+    return res.status(200).json({ ok: true })
+  })
+
+  return app
+}
+
+describe('Compatibilidad de CSRF con clientes SPA', () => {
+  it('debería aceptar el header x-xsrf-token utilizado por axios', async () => {
+    const app = createCsrfApp()
+    const agent = request.agent(app)
+
+    const tokenResponse = await agent.get('/token')
+    const { token } = tokenResponse.body
+
+    expect(tokenResponse.status).toBe(200)
+    expect(typeof token).toBe('string')
+    expect(token.length).toBeGreaterThan(10)
+
+    const mutationResponse = await agent
+      .put('/profile')
+      .set('x-xsrf-token', token)
+      .send({ profileImage: 'https://example.com/avatar.png' })
+
+    expect(mutationResponse.status).toBe(200)
+    expect(mutationResponse.body.ok).toBe(true)
+  })
+
+  it('debería emitir la cookie pública XSRF-TOKEN al solicitar token', async () => {
+    const app = createCsrfApp()
+
+    const tokenResponse = await request(app).get('/token')
+    const cookies = tokenResponse.headers['set-cookie'] || []
+
+    expect(tokenResponse.status).toBe(200)
+    expect(
+      cookies.some((cookieEntry) =>
+        cookieEntry.startsWith(`${CSRF_TOKEN_COOKIE_NAME}=`)
+      )
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
### Motivation
- The profile avatar update endpoint was returning `403` because SPA clients (Axios) send `x-xsrf-token` while the server only accepted `x-csrf-token` and some flows did not ensure the CSRF token was issued before profile mutations.
- Ensure the backend emits a JavaScript-readable CSRF token cookie and provides a reusable API so frontends receive the token during session/refresh flows.

### Description
- Added `issueCsrfToken(req, res)` to `task-management/security/csrfValidator/csrfValidator.js` which issues the public `XSRF-TOKEN` cookie and returns the token string. 
- Extended the CSRF validator to accept the `x-xsrf-token` header (in addition to `x-csrf-token` and `_csrf`) for Axios / SPA compatibility. 
- Updated `GET /api/token/csrf` in `app.js` to use `issueCsrfToken`, return the token in JSON, and handle emission errors. 
- Made `POST /auth/refresh-token` in `task-management/security/jwt/controllers/refreshTokenController.js` call `issueCsrfToken` so the token is available after session renewal. 
- Added `test/security/csrfValidatorCompatibility.test.js` with compatibility tests that verify `x-xsrf-token` acceptance and that the `XSRF-TOKEN` cookie is emitted.

### Testing
- Ran `npm test -- --run test/security/csrfCookieOptions.test.js test/security/csrfProtectionRoutes.test.js test/security/csrfValidatorCompatibility.test.js` and all test files passed. 
- Test summary: `3 files, 7 tests` all succeeded (green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1282ed2088320a7c7203fa22d45c9)