### PR TITLE
Enhance CSRF handling: issue token endpoint, diagnostics, axios compatibility, and tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ import User from './models/user.js'
 import bcrypt from 'bcrypt'
 import cookieParser from 'cookie-parser'
 import csrfValidator, {
-  getCsrfTokenCookieOptions
+  issueCsrfToken
 } from './task-management/security/csrfValidator/csrfValidator.js'
 import applyCsrfProtection from './task-management/security/csrfValidator/applyCsrfProtection.js'
 
@@ -49,10 +49,19 @@ applyMiddlewares(app) // Aplica middlewares generales
 // Ruta pública para obtener token CSRF
 // =====================================
 app.get('/api/token/csrf', csrfValidator, (req, res) => {
-  const token = req.csrfToken()
-  res.cookie('XSRF-TOKEN', token, getCsrfTokenCookieOptions())
+  const token = issueCsrfToken(req, res)
+
+  if (!token) {
+    return res
+      .status(500)
+      .json({ message: 'No fue posible emitir el token CSRF' })
+  }
+
   console.log('[CSRF] Token CSRF generado y enviado')
-  res.status(200).json({ message: 'Token CSRF enviado correctamente' })
+  return res.status(200).json({
+    message: 'Token CSRF enviado correctamente',
+    token
+  })
 })
 
 // =====================================

--- a/task-management/security/csrfValidator/csrfRequestDiagnostics.js
+++ b/task-management/security/csrfValidator/csrfRequestDiagnostics.js
@@ -1,0 +1,35 @@
+/**
+ * Construye un resumen seguro del estado CSRF de una request.
+ *
+ * @param {import('express').Request} req - Request entrante.
+ * @returns {{
+ *  origin: string,
+ *  referer: string,
+ *  method: string,
+ *  path: string,
+ *  hasCsrfSecretCookie: boolean,
+ *  hasXsrfTokenCookie: boolean,
+ *  hasCsrfHeader: boolean,
+ *  hasXsrfHeader: boolean,
+ *  hasAuthCookie: boolean,
+ *  hasRefreshCookie: boolean
+ * }} Contexto útil para diagnóstico en logs.
+ */
+const getCsrfRequestDiagnostics = (req) => {
+  const cookies = req.cookies || {}
+
+  return {
+    origin: req.headers.origin || 'sin-origin',
+    referer: req.headers.referer || 'sin-referer',
+    method: req.method,
+    path: req.originalUrl || req.path,
+    hasCsrfSecretCookie: Boolean(cookies.csrfSecret),
+    hasXsrfTokenCookie: Boolean(cookies['XSRF-TOKEN']),
+    hasCsrfHeader: Boolean(req.get('x-csrf-token')),
+    hasXsrfHeader: Boolean(req.get('x-xsrf-token')),
+    hasAuthCookie: Boolean(cookies.token),
+    hasRefreshCookie: Boolean(cookies.refreshToken)
+  }
+}
+
+export default getCsrfRequestDiagnostics

--- a/task-management/security/csrfValidator/csrfValidator.js
+++ b/task-management/security/csrfValidator/csrfValidator.js
@@ -1,10 +1,13 @@
 import Tokens from 'csrf'
 import logger from '../../../utils/winstonLogger/loggers.js'
+import getCsrfRequestDiagnostics from './csrfRequestDiagnostics.js'
 
 // Instancia única para generar y validar tokens CSRF con secretos por cookie.
 const csrfTokens = new Tokens()
 const CSRF_SECRET_COOKIE_NAME = 'csrfSecret'
 const CSRF_HEADER_NAME = 'x-csrf-token'
+const XSRF_HEADER_NAME = 'x-xsrf-token'
+const CSRF_TOKEN_COOKIE_NAME = 'XSRF-TOKEN'
 
 /**
  * Define opciones de cookie compatibles con flujos same-site y cross-site.
@@ -74,6 +77,30 @@ const ensureCsrfSecret = (req, res) => {
 }
 
 /**
+ * Genera y envía un token CSRF legible por JavaScript para clientes SPA.
+ *
+ * @param {import('express').Request} req - Solicitud HTTP entrante.
+ * @param {import('express').Response} res - Respuesta HTTP saliente.
+ * @returns {string | null} Token CSRF emitido o null si no fue posible.
+ */
+const issueCsrfToken = (req, res) => {
+  const csrfSecret = ensureCsrfSecret(req, res)
+  if (!csrfSecret) {
+    return null
+  }
+
+  const token = csrfTokens.create(csrfSecret)
+  res.cookie(CSRF_TOKEN_COOKIE_NAME, token, getCsrfTokenCookieOptions())
+
+  logger.info('[CSRF] Token CSRF emitido para cliente', {
+    ...getCsrfRequestDiagnostics(req),
+    tokenLength: token.length
+  })
+
+  return token
+}
+
+/**
  * Middleware CSRF para rutas de emisión y validación de token.
  *
  * @param {import('express').Request} req - Solicitud HTTP entrante.
@@ -83,7 +110,10 @@ const ensureCsrfSecret = (req, res) => {
  */
 const csrfValidator = (req, res, next) => {
   if (!req.cookies) {
-    logger.error('[CSRF] cookie-parser no está aplicado antes de csrfValidator')
+    logger.error(
+      '[CSRF] cookie-parser no está aplicado antes de csrfValidator',
+      getCsrfRequestDiagnostics(req)
+    )
     return res
       .status(500)
       .json({ message: 'Error interno de configuración CSRF' })
@@ -92,7 +122,10 @@ const csrfValidator = (req, res, next) => {
   // Garantizamos que siempre exista un secreto para construir o validar tokens.
   const csrfSecret = ensureCsrfSecret(req, res)
   if (!csrfSecret) {
-    logger.error('[CSRF] No fue posible generar el secreto CSRF')
+    logger.error(
+      '[CSRF] No fue posible generar el secreto CSRF',
+      getCsrfRequestDiagnostics(req)
+    )
     return res
       .status(500)
       .json({ message: 'Error interno de configuración CSRF' })
@@ -110,21 +143,37 @@ const csrfValidator = (req, res, next) => {
   }
 
   // Obtenemos el token enviado por header o por body para soportar clientes variados.
-  const sentToken = req.get(CSRF_HEADER_NAME) || req.body?._csrf
+  const sentToken =
+    req.get(CSRF_HEADER_NAME) || req.get(XSRF_HEADER_NAME) || req.body?._csrf
   const isTokenValid =
     typeof sentToken === 'string' && csrfTokens.verify(csrfSecret, sentToken)
 
   if (!isTokenValid) {
-    logger.warn('[CSRF] Token inválido o ausente', {
-      path: req.path,
+    const diagnostics = {
+      ...getCsrfRequestDiagnostics(req),
       ip: req.ip
+    }
+
+    logger.warn('[CSRF] Token inválido o ausente', diagnostics)
+
+    return res.status(403).json({
+      message: 'CSRF token inválido o ausente',
+      diagnostics:
+        process.env.NODE_ENV === 'production' ? undefined : diagnostics
     })
-    return res.status(403).json({ message: 'CSRF token inválido o ausente' })
   }
 
-  logger.debug('[CSRF] Token verificado correctamente')
+  logger.debug(
+    '[CSRF] Token verificado correctamente',
+    getCsrfRequestDiagnostics(req)
+  )
   return next()
 }
 
 export default csrfValidator
-export { getCsrfSecretCookieOptions, getCsrfTokenCookieOptions }
+export {
+  getCsrfSecretCookieOptions,
+  getCsrfTokenCookieOptions,
+  issueCsrfToken,
+  CSRF_TOKEN_COOKIE_NAME
+}

--- a/task-management/security/jwt/controllers/refreshTokenController.js
+++ b/task-management/security/jwt/controllers/refreshTokenController.js
@@ -2,6 +2,7 @@ import User from '../../../../models/user.js'
 import { signAndSendAccessToken } from '../helpers/token/signAndSendAccessToken.js'
 import { verifyToken } from '../helpers/token/verifyToken.js'
 import logger from '../../../../utils/winstonLogger/loggers.js'
+import { issueCsrfToken } from '../../csrfValidator/csrfValidator.js'
 
 /**
  * Controlador que renueva el token de acceso utilizando el refresh token.
@@ -44,6 +45,7 @@ const refreshTokenController = async (req, res) => {
     }
 
     const accessToken = signAndSendAccessToken(res, user.id, '1h')
+    issueCsrfToken(req, res)
 
     logger.info('Token de acceso renovado correctamente', {
       userId: user.id,

--- a/test/security/csrfRequestDiagnostics.test.js
+++ b/test/security/csrfRequestDiagnostics.test.js
@@ -1,0 +1,50 @@
+import express from 'express'
+import cookieParser from 'cookie-parser'
+import request from 'supertest'
+import { afterEach, describe, it, expect } from 'vitest'
+import csrfValidator from '../../task-management/security/csrfValidator/csrfValidator.js'
+
+/**
+ * Crea una app de prueba para validar el payload de diagnóstico CSRF.
+ *
+ * @returns {import('express').Express} Aplicación preparada para tests.
+ */
+const createApp = () => {
+  const app = express()
+
+  app.use(cookieParser())
+  app.use(express.json())
+
+  app.put('/auth/profile/avatar', csrfValidator, (req, res) => {
+    return res.status(200).json({ ok: true })
+  })
+
+  return app
+}
+
+describe('Diagnóstico en errores CSRF', () => {
+  afterEach(() => {
+    delete process.env.NODE_ENV
+  })
+
+  it('debería devolver contexto de diagnóstico en entornos no productivos', async () => {
+    process.env.NODE_ENV = 'test'
+    const app = createApp()
+
+    const response = await request(app)
+      .put('/auth/profile/avatar')
+      .set('origin', 'https://invexly.netlify.app')
+      .send({ profileImage: 'x' })
+
+    expect(response.status).toBe(403)
+    expect(response.body.message).toBe('CSRF token inválido o ausente')
+    expect(response.body.diagnostics).toMatchObject({
+      origin: 'https://invexly.netlify.app',
+      method: 'PUT',
+      hasCsrfHeader: false,
+      hasXsrfHeader: false,
+      hasCsrfSecretCookie: false,
+      hasXsrfTokenCookie: false
+    })
+  })
+})

--- a/test/security/csrfValidatorCompatibility.test.js
+++ b/test/security/csrfValidatorCompatibility.test.js
@@ -1,0 +1,68 @@
+import express from 'express'
+import cookieParser from 'cookie-parser'
+import request from 'supertest'
+import { describe, it, expect } from 'vitest'
+import csrfValidator, {
+  issueCsrfToken,
+  CSRF_TOKEN_COOKIE_NAME
+} from '../../task-management/security/csrfValidator/csrfValidator.js'
+
+/**
+ * Construye una app mínima para comprobar compatibilidad CSRF
+ * con clientes axios y flujo de emisión de token.
+ *
+ * @returns {import('express').Express} Aplicación de pruebas.
+ */
+const createCsrfApp = () => {
+  const app = express()
+
+  app.use(cookieParser())
+  app.use(express.json())
+
+  app.get('/token', csrfValidator, (req, res) => {
+    const token = issueCsrfToken(req, res)
+    return res.status(200).json({ token })
+  })
+
+  app.put('/profile', csrfValidator, (req, res) => {
+    return res.status(200).json({ ok: true })
+  })
+
+  return app
+}
+
+describe('Compatibilidad de CSRF con clientes SPA', () => {
+  it('debería aceptar el header x-xsrf-token utilizado por axios', async () => {
+    const app = createCsrfApp()
+    const agent = request.agent(app)
+
+    const tokenResponse = await agent.get('/token')
+    const { token } = tokenResponse.body
+
+    expect(tokenResponse.status).toBe(200)
+    expect(typeof token).toBe('string')
+    expect(token.length).toBeGreaterThan(10)
+
+    const mutationResponse = await agent
+      .put('/profile')
+      .set('x-xsrf-token', token)
+      .send({ profileImage: 'https://example.com/avatar.png' })
+
+    expect(mutationResponse.status).toBe(200)
+    expect(mutationResponse.body.ok).toBe(true)
+  })
+
+  it('debería emitir la cookie pública XSRF-TOKEN al solicitar token', async () => {
+    const app = createCsrfApp()
+
+    const tokenResponse = await request(app).get('/token')
+    const cookies = tokenResponse.headers['set-cookie'] || []
+
+    expect(tokenResponse.status).toBe(200)
+    expect(
+      cookies.some((cookieEntry) =>
+        cookieEntry.startsWith(`${CSRF_TOKEN_COOKIE_NAME}=`)
+      )
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
### Motivation

- Improve CSRF token issuance for SPA clients and make diagnostics more actionable when CSRF checks fail.  
- Support common client behavior (like axios `x-xsrf-token`) and ensure token issuance on auth refresh flows.  
- Add automated tests to validate compatibility and diagnostic payloads.

### Description

- Added `issueCsrfToken` to `csrfValidator` to generate a JS-readable token, set the `XSRF-TOKEN` cookie, and return the token while logging request diagnostics via `getCsrfRequestDiagnostics`.
- Introduced `getCsrfRequestDiagnostics` to produce a secure summary of CSRF-related request state for logging and error diagnostics.  
- Expanded CSRF middleware to accept `x-xsrf-token` in addition to `x-csrf-token` and to include diagnostics in 403 responses when not in production.  
- Updated `app.js` `/api/token/csrf` route to use `issueCsrfToken` and return the token in the JSON response.  
- Ensured `refreshTokenController` calls `issueCsrfToken` when issuing a new access token so clients receive an up-to-date CSRF token on refresh.  
- Exported `CSRF_TOKEN_COOKIE_NAME` and cookie option helpers from the CSRF module for testability and reuse.

### Testing

- Added `test/security/csrfRequestDiagnostics.test.js` and `test/security/csrfValidatorCompatibility.test.js` and executed them with Vitest; both tests passed.  
- Verified the CSRF compatibility test covers `issueCsrfToken`, the `XSRF-TOKEN` cookie emission, and acceptance of the `x-xsrf-token` header; assertions succeeded.  
- Ran the diagnostics test to confirm non-production 403 responses include the expected diagnostic payload; the test succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1282ed2088320a7c7203fa22d45c9)